### PR TITLE
feat: automated test and release using github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+# Release the project on sonatype https://github.com/olafurpg/sbt-ci-release
+name: Release
+on:
+  push:
+    branches: [master, main]
+    tags: ["*"]
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-gpg@v3
+      - run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+# Run tests (slightly modified from https://www.scala-sbt.org/1.x/docs/GitHub-Actions-with-sbt.html)
+name: Test
+on:
+  pull_request:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Setup Scala
+      uses: olafurpg/setup-scala@v10
+      with:
+        java-version: "adopt@1.8"
+    - name: Build and Test
+      run: sbt -v -Dfile.encoding=UTF-8 +test

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ dist/*
 target/
 lib_managed/
 src_managed/
-project/*
+project/project
+project/target
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,10 @@
 /* This file is part of the scala-tptp-parser library. See README.md and LICENSE.txt in root directory for more information. */
 
-inThisBuild(List(
-  organization := "io.github.leoprover",
-  homepage := Some(url("https://github.com/leoprover/scala-tptp-parser")),
-  licenses := List("MIT" -> url("https://opensource.org/licenses/MIT")),
-  developers := List(
-    Developer(
-      "lex-lex",
-      "Alexander Steen",
-      "alexander.steen@uni.lu",
-      url("https://www.alexandersteen.de/")
-    )
-  )
-))
-
 lazy val tptpParser = (project in file("."))
   .settings(
+    organization := "io.github.leoprover",
     name := "scala-tptp-parser",
+    homepage := Some(url("https://github.com/leoprover/scala-tptp-parser")),
     description := """scala-tptp-parser is a library for parsing the input languages of the TPTP infrastructure
                      | for knowledge representation and reasoning.
                      |
@@ -32,13 +20,21 @@ lazy val tptpParser = (project in file("."))
                      | Currently, parsing of TFX (FOOL) and TCF (typed CNF) is not supported. Apart from that, the parser
                      | should cover every other language dialect.
                      | The parser is based on v7.4.0.3 of the TPTP syntax BNF (http://tptp.org/TPTP/SyntaxBNF.html).""".stripMargin,
-    version := "1.3",
-    organization := "org.leo",
     scalaVersion := "2.13.4",
+    // Version number explicitly removed as this is handled by the release plugin
+
     scmInfo := Some(ScmInfo(
       browseUrl = url("https://github.com/leoprover/scala-tptp-parser"),
       connection = "scm:git:git@github.com:leoprover/scala-tptp-parser.git"
     )),
+    developers := List(
+      Developer(
+        "lex-lex",
+        "Alexander Steen",
+        "alx.steen@gmail.com",
+        url("https://www.alexandersteen.de/")
+      )
+    ),
     licenses += "MIT" -> url("https://opensource.org/licenses/MIT"),
 
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.2" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,19 @@
 /* This file is part of the scala-tptp-parser library. See README.md and LICENSE.txt in root directory for more information. */
 
+inThisBuild(List(
+  organization := "io.github.leoprover",
+  homepage := Some(url("https://github.com/leoprover/scala-tptp-parser")),
+  licenses := List("MIT" -> url("https://opensource.org/licenses/MIT")),
+  developers := List(
+    Developer(
+      "lex-lex",
+      "Alexander Steen",
+      "alexander.steen@uni.lu",
+      url("https://www.alexandersteen.de/")
+    )
+  )
+))
+
 lazy val tptpParser = (project in file("."))
   .settings(
     name := "scala-tptp-parser",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.6")


### PR DESCRIPTION
This PR is supposed to add automated test and release to maven central steps using github actions. It is using the "sbt-ci-release" plugin from https://github.com/olafurpg/sbt-ci-release. Sadly I can not configure and test everything since the release needs accounts and secrets I should not know.

Open todos would be:
- [x] check if you agree with the data in build.sbt
- [x] create a sonatype account and get publishing rights for a domain name (currently io.github.leoprover is configured) https://github.com/olafurpg/sbt-ci-release#sonatype
- [x] create tokens for that account https://github.com/olafurpg/sbt-ci-release#optional-create-user-tokens
- [x] generate and publish a key to sign the release https://github.com/olafurpg/sbt-ci-release#gpg
- [x] configure the github action secrets https://github.com/olafurpg/sbt-ci-release#secrets

After that we should be able to merge this and see the tests running (.github/workflows/test.yml) and after committing a tag also see an automated release (.github/workflows/release.yml).