### PR TITLE
feat: export to javascript using scala-js

### DIFF
--- a/.github/workflows/scalajs.yml
+++ b/.github/workflows/scalajs.yml
@@ -1,0 +1,24 @@
+# Build JS files using https://www.scala-js.org/
+name: ScalaJS
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+jobs:
+  build-scala-js:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Setup Scala
+      uses: olafurpg/setup-scala@v10
+      with:
+        java-version: "adopt@1.8"
+    - name: Build and Test
+      run: sbt -v -Dfile.encoding=UTF-8 +fullLinkJS
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+         name: scala-js
+         path: target/scala-2.13/scala-tptp-parser-opt/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ bin/*
 *.swp
 *~
 ext_config
+
+
+# OSX
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ libraryDependencies += "io.github.leoprover" %% "scala-tptp-parser" % "1.3"
 ### Non-sbt-projects
 In order to use the library with a non-sbt project, you can simply compile the library and use the class files as an unmanaged dependency/class path. The latest release JAR can also be downloaded from the Maven Central link above.
 
+#### ScalaJS
+This project supports very basic (and untested) export to JavaScript ESModule using [ScalaJS](https://www.scala-js.org/).
+
+To compile an unoptimized version use `sbt fastLinkJS`, for an optimized version `sbt fullLinkJS`.
+
+To use it in your code import the TPTPParser Object:
+
+```javascript
+    import {TPTPParser} from "./main.js";
+    
+    console.log(TPTPParser.annotatedTHF("thf(f, axiom, ![X:$i]: (p @ X))."));
+```
+
 ## Usage
 The parser object `TPTPParser` offers several methods for parsing TPTP problems, annotated formulas or simple formulas. The input is transformed into an
 abstract syntax tree (AST) provided at `leo.datastructures.TPTP`. The ASTs are mostly case classes that can be further processed by pattern matching.

--- a/build.sbt
+++ b/build.sbt
@@ -41,3 +41,6 @@ lazy val tptpParser = (project in file("."))
 
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.5" % "test"
   )
+  .enablePlugins(ScalaJSPlugin)
+
+scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")

--- a/src/main/scala/leo/modules/input/TPTPParser.scala
+++ b/src/main/scala/leo/modules/input/TPTPParser.scala
@@ -8,6 +8,7 @@ import leo.datastructures.TPTP.TCFAnnotated
 import java.util.NoSuchElementException
 import scala.annotation.tailrec
 import scala.io.Source
+import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 
 /**
  *
@@ -54,6 +55,8 @@ import scala.io.Source
  * @note Limitations: Currently, FOOL logic (i.e., TFX) cannot be parsed.
  * @since January 2021
  */
+@JSExportTopLevel("TPTPParser")
+@JSExportAll
 object TPTPParser {
   import datastructures.TPTP.{Problem, AnnotatedFormula, THFAnnotated, TFFAnnotated,
     FOFAnnotated, CNFAnnotated, TPIAnnotated}


### PR DESCRIPTION
# What
This PR adds an **experimental** export to javascript to the parser using [Scala-JS](https://www.scala-js.org/). I was playing around with using the parser in a JS context (for parsing in a browser) and saw it is actually reasonably easy to do. This adds overhead and untested code so I am **100% okay with this PR not being merged**, I just figured since I already did the work myself I can offer you the result.

# Demo
If you serve the generated file locally this is a minimal working example html:

```html
<script type="module">
	import {TPTPParser} from "http://localhost:8000/main.js";

	console.log(TPTPParser.annotatedTHF("thf(f, axiom, ![X:$i]: (p @ X))."));
	console.log(TPTPParser.thf("![X:$i]: (p @ X)"));
</script>
```

That produces these console.logs in which you can see the generated objects for the parsed formulas.

<img width="801" alt="Screenshot 2021-04-28 at 21 51 50" src="https://user-images.githubusercontent.com/3462888/116520568-307d0e80-a8d3-11eb-9398-c1a0b547797f.png">

# Issues
- The generated JS code is 1.5mb big
- The code is untested
- The compilation might brake at any point in the future, e.g. if you introduce scala only libraries as dependencies
