### PR TITLE
fix typo in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A small sample application can be seen below:
 
 ```scala
 import leo.modules.input.{TPTPParser => Parser}
-import TPTPParser.TPTPParseException
+import Parser.TPTPParseException
 import leo.datastructures.TPTP.THF
 
 try {


### PR DESCRIPTION
Tried to get started with an example from README, but it seems to have a minor import problem.

sbt.version=1.6.1
scalaVersion := "2.13.10"
libraryDependencies += "io.github.leoprover" %% "scala-tptp-parser" % "1.6.4"